### PR TITLE
dreameater fix

### DIFF
--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -307,7 +307,7 @@ exports.BattleMovedex = {
 		basePower: 200,
 		type: "Ghost",
 		onTryHit: function (target) {
-			if (target.status !== 'psn') {
+			if (target.status !== 'psn' || target.status !== 'tox' || target.status !== 'slp') {
 				this.add('-immune', target, '[msg]');
 				return null;
 			}


### PR DESCRIPTION
should work against sleeping, poisoned, or badly poisoned targets
